### PR TITLE
Don't call rstrip on the result of Node.text()

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -116,11 +116,9 @@ class Node:
             # Combine any adjacent text nodes since we modified the tree
             self.node.smooth()
 
-            asciidoc_output = self.block_separator(**kwargs).join(
+            return self.block_separator(**kwargs).join(
                 asciidoc for asciidoc in self.asciidoc_contents(**kwargs) if asciidoc
             )
-
-            return asciidoc_output
 
         return "".join(self.asciidoc_contents(**kwargs))
 
@@ -721,7 +719,7 @@ class ParameterlistNode(Node):
 
 class ParameternamelistNode(Node):
     def to_asciidoc(self, **kwargs):
-        return f"`{escape_text(self.text('parametername')).rstrip()}`::"
+        return f"`{escape_text(self.text('parametername'))}`::"
 
 
 class ParameterdescriptionNode(Node):
@@ -880,7 +878,7 @@ class TypedefMemberdefNode(Node):
         output = [
             title(self.text("name"), 5 + kwargs.get("depth", 0), self.attributes())
         ]
-        output.append(f"[.memname]`{escape_text(self.text('definition')).rstrip()}`")
+        output.append(f"[.memname]`{escape_text(self.text('definition'))}`")
         kwargs["depth"] = 5 + kwargs.get("depth", 0)
         kwargs["documentation"] = True
         briefdescription = self.child("briefdescription").to_asciidoc(**kwargs)
@@ -901,7 +899,7 @@ class EnumMemberdefNode(Node):
             )
         ]
         if name:
-            output.append(f"[.memname]`enum {escape_text(name).rstrip()}`")
+            output.append(f"[.memname]`enum {escape_text(name)}`")
         else:
             output.append("[.memname]`anonymous enum`")
         kwargs["depth"] = 5 + kwargs.get("depth", 0)
@@ -955,7 +953,7 @@ class VariableMemberdefNode(Node):
                 )
             )
         else:
-            output.append(f"[.memname]`{escape_text(definition).rstrip()}`")
+            output.append(f"[.memname]`{escape_text(definition)}`")
         kwargs["depth"] = 5 + kwargs.get("depth", 0)
         kwargs["documentation"] = True
         briefdescription = self.child("briefdescription").to_asciidoc(**kwargs)
@@ -998,7 +996,7 @@ class DefineMemberdefNode(Node):
                 )
         else:
             output.append(
-                f"[.memname]`#define {escape_text(name)}{escape_text(argsstring).rstrip()}`"
+                f"[.memname]`#define {escape_text(name)}{escape_text(argsstring)}`"
             )
         kwargs["depth"] = 5 + kwargs.get("depth", 0)
         kwargs["documentation"] = True
@@ -1038,7 +1036,7 @@ class FunctionSectiondefNode(Node):
             function.append(
                 f" <<{memberdef.id},{escape_text(memberdef.text('name'))}>> "
             )
-            function.append(f"{escape_text(memberdef.text('argsstring')).rstrip()}`:: ")
+            function.append(f"{escape_text(memberdef.text('argsstring'))}`:: ")
             briefdescription = memberdef.child("briefdescription").to_asciidoc(**kwargs)
             if briefdescription:
                 function.append(briefdescription)

--- a/tests/test_doxygenindex_node.py
+++ b/tests/test_doxygenindex_node.py
@@ -6,7 +6,7 @@ from doxygentoasciidoc.nodes import DoxygenindexNode
 def test_to_asciidoc(tmp_path):
     with open(f"{tmp_path}/group__hardware.xml", "w", encoding="utf-8") as hardware:
         hardware.write(
-            """
+            """\
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <doxygen xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="compound.xsd" version="1.9.7" xml:lang="en-US">
   <compounddef id="group__hardware" kind="group">
@@ -77,8 +77,6 @@ def test_to_asciidoc(tmp_path):
     asciidoc = DoxygenindexNode(
         BeautifulSoup(xml, "xml").doxygenindex, xmldir=tmp_path
     ).to_asciidoc()
-
-    print(asciidoc)
 
     assert asciidoc == dedent(
         """\


### PR DESCRIPTION
The result of calling Node.text() should already have leading and trailing whitespace stripped so there's no need to call rstrip() on it.  This will hopefully help zero in on where trailing whitespace is creeping in from certain bits of Doxygen XML.

This leaves the following places where we explicit strip trailing whitespace:

1. In `<computeroutput>` elements
2. In function definitions (where the `<type>` of a `<param>` might have trailing space)
3. In a macro definition (where the `<initializer>` might have trailing space)
