### PR TITLE
Add arguments to variables

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1191,8 +1191,12 @@ class VariableSectiondefNode(Node):
             variable = ["`"]
             variable.append(memberdef.child("type").to_asciidoc(**kwargs))
             variable.append(
-                f" <<{memberdef.id},{escape_text(memberdef.text('name'))}>>`:: "
+                f" <<{memberdef.id},{escape_text(memberdef.text('name'))}>>"
             )
+            argsstring = memberdef.text("argsstring")
+            if argsstring:
+                variable.append(argsstring)
+            variable.append("`:: ")
             briefdescription = memberdef.child("briefdescription").to_asciidoc(**kwargs)
             if briefdescription:
                 variable.append(briefdescription)

--- a/tests/test_variable_sectiondef_node.py
+++ b/tests/test_variable_sectiondef_node.py
@@ -1,3 +1,5 @@
+# pylint: disable=line-too-long
+
 from textwrap import dedent
 from bs4 import BeautifulSoup
 from doxygentoasciidoc.nodes import VariableSectiondefNode
@@ -30,7 +32,7 @@ def test_to_asciidoc():
         """\
         ===== Variables
 
-        `uint32_t <<float_init_rom_8c_1aea98df4cf9adff2a025dc4a09c814986,sf_table>>`:: {empty}"""
+        `uint32_t <<float_init_rom_8c_1aea98df4cf9adff2a025dc4a09c814986,sf_table>>[SF_TABLE_V2_SIZE/2]`:: {empty}"""
     )
 
 
@@ -65,4 +67,63 @@ def test_to_details_asciidoc():
         ====== sf_table
 
         [.memname]`uint32_t sf_table[SF_TABLE_V2_SIZE/2]`"""
+    )
+
+
+def test_bug():
+    xml = """\
+        <sectiondef kind="var">
+          <memberdef kind="variable" id="group__cyw43__driver_1gafe7528793baa39a05a1c4ff55f5b5807" prot="public" static="no" extern="yes" mutable="no">
+            <type><ref refid="struct__cyw43__t" kindref="compound">cyw43_t</ref></type>
+            <definition>cyw43_t cyw43_state</definition>
+            <argsstring></argsstring>
+            <name>cyw43_state</name>
+            <briefdescription>
+            </briefdescription>
+            <detaileddescription>
+            </detaileddescription>
+            <inbodydescription>
+            </inbodydescription>
+            <location file="cyw43.h" line="154" column="16" bodyfile="cyw43_ctrl.c" bodystart="68" bodyend="-1" declfile="cyw43.h" declline="154" declcolumn="16"/>
+          </memberdef>
+          <memberdef kind="variable" id="group__cyw43__driver_1ga65550517babd8db2d2a052f41de6ae33" prot="public" static="no" extern="yes" mutable="no">
+            <type>void(*</type>
+            <definition>void(* cyw43_poll) (void)</definition>
+            <argsstring>)(void)</argsstring>
+            <name>cyw43_poll</name>
+            <briefdescription>
+            </briefdescription>
+            <detaileddescription>
+            </detaileddescription>
+            <inbodydescription>
+            </inbodydescription>
+            <location file="cyw43.h" line="155" column="8" bodyfile="cyw43_ctrl.c" bodystart="69" bodyend="-1" declfile="cyw43.h" declline="155" declcolumn="8"/>
+          </memberdef>
+          <memberdef kind="variable" id="group__cyw43__driver_1ga8345872c237308a5e4e984060f9f399f" prot="public" static="no" extern="yes" mutable="no">
+            <type>uint32_t</type>
+            <definition>uint32_t cyw43_sleep</definition>
+            <argsstring></argsstring>
+            <name>cyw43_sleep</name>
+            <briefdescription>
+            </briefdescription>
+            <detaileddescription>
+            </detaileddescription>
+            <inbodydescription>
+            </inbodydescription>
+            <location file="cyw43.h" line="156" column="17" bodyfile="cyw43_ctrl.c" bodystart="70" bodyend="-1" declfile="cyw43.h" declline="156" declcolumn="17"/>
+          </memberdef>
+        </sectiondef>
+      """
+
+    asciidoc = VariableSectiondefNode(
+        BeautifulSoup(xml, "xml").sectiondef
+    ).to_asciidoc()
+
+    assert asciidoc == dedent(
+        """\
+        ===== Variables
+
+        `<<struct_cyw43_t,cyw43_t>> <<group_cyw43_driver_1gafe7528793baa39a05a1c4ff55f5b5807,cyw43_state>>`:: {empty}
+        `void(++*++ <<group_cyw43_driver_1ga65550517babd8db2d2a052f41de6ae33,cyw43_poll>>)(void)`:: {empty}
+        `uint32_t <<group_cyw43_driver_1ga8345872c237308a5e4e984060f9f399f,cyw43_sleep>>`:: {empty}"""
     )


### PR DESCRIPTION
As raised by @lurch, variables with a non-empty argsstring are lacking that part of their definition in the "Variables" section of the documentation but not the "Variable Documentation" section as that uses a different element to fetch the full definition.

| Before | After |
| --- | --- |
| ![Screenshot from 2024-08-15 11-07-37](https://github.com/user-attachments/assets/14a2025d-633e-4036-b2e9-b3163a809d35) |  ![Screenshot 2024-08-15 at 14 47 10](https://github.com/user-attachments/assets/7735f7d9-bd64-4984-b04f-989ef01669e9) |
