### PR TITLE
Support paragraphs with user defined headings

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -686,6 +686,20 @@ class SimplesectNode(Node):
 
             return "".join(output)
 
+        if kind == "par":
+            output = []
+
+            title_ = self.text("title")
+            if title_:
+                output.append(f"*{escape_text(title_)}*")
+
+            for para in self.children("para"):
+                asciidoc = para.to_asciidoc(**kwargs)
+                if asciidoc:
+                    output.append(asciidoc)
+
+            return "\n\n".join(output)
+
         return super().to_asciidoc(**kwargs)
 
 

--- a/tests/test_simplesect_node.py
+++ b/tests/test_simplesect_node.py
@@ -73,3 +73,35 @@ def test_two_sibling_simplesects_with_see_kind(tmp_path):
         <<bar,bar()>>
         --"""
     )
+
+
+def test_simplesect_with_par_kind():
+    xml = """<simplesect kind="par"><title>LwIP HTTP server</title><para/>
+</simplesect>"""
+
+    asciidoc = SimplesectNode(BeautifulSoup(xml, "xml").simplesect).to_asciidoc()
+
+    assert asciidoc == """*LwIP HTTP server*"""
+
+
+def test_simplesect_with_par_kind_and_paragraph():
+    xml = """<simplesect kind="par"><title>LwIP HTTP server</title><para>Contents of the paragraph.</para>
+</simplesect>"""
+
+    asciidoc = SimplesectNode(BeautifulSoup(xml, "xml").simplesect).to_asciidoc()
+
+    assert asciidoc == dedent(
+        """\
+        *LwIP HTTP server*
+
+        Contents of the paragraph."""
+    )
+
+
+def test_simplesect_with_par_kind_paragraph_and_no_title():
+    xml = """<simplesect kind="par"><para>Contents of the paragraph.</para>
+</simplesect>"""
+
+    asciidoc = SimplesectNode(BeautifulSoup(xml, "xml").simplesect).to_asciidoc()
+
+    assert asciidoc == """Contents of the paragraph."""


### PR DESCRIPTION
Add support for the `\par` keyword (see https://doxygen.nl/manual/commands.html#cmdpar) which starts a paragraph with an optional user defined heading.

e.g. with the following comment:

```
  * \par LwIP HTTP server
  *
  * To make use of the LwIP HTTP server you need to provide the HTML that the server will return to the client.
  * This is done by compiling the content directly into the executable.
```

Produce the following:

<img width="562" alt="Screenshot 2025-04-15 at 15 06 04" src="https://github.com/user-attachments/assets/1494ea0c-215e-4048-a2f5-b06d876deeef" />
